### PR TITLE
TOSHI Shopify fix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, v18 ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, v18 ]
 
 jobs:
   build:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+18.1.3 (Jun 2, 2022)
+----------
+* Update browser_sniffer to 2.0.0
+
 18.1.2 (Mar 3, 2022)
 ----------
 * Use the App Bridge 2.0 redirect when attempting to break out of an iframe. This happens when an app is installed, requires new access scopes, or re-authentication because the login session is expired. [#1376](https://github.com/Shopify/shopify_app/pull/1376)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    shopify_app (18.1.2)
+    shopify_app (18.1.3)
       browser_sniffer (~> 2.0)
       jwt (>= 2.2.3)
       omniauth-rails_csrf_protection
@@ -94,16 +94,16 @@ GEM
     crass (1.0.6)
     debug_inspector (0.0.3)
     erubi (1.10.0)
-    faraday (2.2.0)
+    faraday (2.3.0)
       faraday-net_http (~> 2.0)
       ruby2_keywords (>= 0.0.4)
-    faraday-net_http (2.0.1)
+    faraday-net_http (2.0.3)
     globalid (1.0.0)
       activesupport (>= 5.0)
-    graphql (1.13.10)
-    graphql-client (0.17.0)
+    graphql (2.0.9)
+    graphql-client (0.18.0)
       activesupport (>= 3.0)
-      graphql (~> 1.10)
+      graphql
     hashdiff (1.0.1)
     hashie (5.0.0)
     i18n (1.9.1)
@@ -132,9 +132,9 @@ GEM
       multi_json (~> 1.3)
       multi_xml (~> 0.5)
       rack (>= 1.2, < 3)
-    omniauth (2.0.4)
+    omniauth (2.1.0)
       hashie (>= 3.4.6)
-      rack (>= 1.6.2, < 3)
+      rack (>= 2.2.3)
       rack-protection
     omniauth-oauth2 (1.7.2)
       oauth2 (~> 1.4)
@@ -219,7 +219,7 @@ GEM
       activeresource (>= 4.1.0)
       graphql-client
       rack
-    sprockets (4.0.2)
+    sprockets (4.0.3)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (3.4.2)
@@ -259,4 +259,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   2.3.5
+   2.3.7

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     shopify_app (18.1.2)
-      browser_sniffer (~> 1.4.0)
+      browser_sniffer (~> 2.0)
       jwt (>= 2.2.3)
       omniauth-rails_csrf_protection
       omniauth-shopify-oauth2 (~> 2.3)
@@ -85,7 +85,7 @@ GEM
     ast (2.4.1)
     binding_of_caller (0.8.0)
       debug_inspector (>= 0.0.1)
-    browser_sniffer (1.4.0)
+    browser_sniffer (2.0.0)
     builder (3.2.4)
     byebug (11.1.3)
     coderay (1.1.3)

--- a/lib/shopify_app.rb
+++ b/lib/shopify_app.rb
@@ -38,6 +38,7 @@ module ShopifyApp
   # controller concerns
   require 'shopify_app/controller_concerns/csrf_protection'
   require 'shopify_app/controller_concerns/localization'
+  require "shopify_app/controller_concerns/frame_ancestors"
   require 'shopify_app/controller_concerns/itp'
   require 'shopify_app/controller_concerns/login_protection'
   require 'shopify_app/controller_concerns/embedded_app'

--- a/lib/shopify_app/controller_concerns/embedded_app.rb
+++ b/lib/shopify_app/controller_concerns/embedded_app.rb
@@ -3,6 +3,8 @@ module ShopifyApp
   module EmbeddedApp
     extend ActiveSupport::Concern
 
+    include ShopifyApp::FrameAncestors
+
     included do
       if ShopifyApp.configuration.embedded_app?
         after_action(:set_esdk_headers)

--- a/lib/shopify_app/controller_concerns/frame_ancestors.rb
+++ b/lib/shopify_app/controller_concerns/frame_ancestors.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module ShopifyApp
+  module FrameAncestors
+    extend ActiveSupport::Concern
+
+    included do
+      content_security_policy do |policy|
+        policy.frame_ancestors(-> do
+          domain_host = current_shopify_domain || "*.myshopify.com"
+          "https://#{domain_host} https://admin.shopify.com;"
+        end)
+      end
+    end
+  end
+end

--- a/lib/shopify_app/version.rb
+++ b/lib/shopify_app/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module ShopifyApp
-  VERSION = '18.1.2'
+  VERSION = '18.1.3'
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shopify_app",
-  "version": "18.1.2",
+  "version": "18.1.3",
   "repository": "git@github.com:Shopify/shopify_app.git",
   "author": "Shopify",
   "license": "MIT",

--- a/shopify_app.gemspec
+++ b/shopify_app.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
 
   s.metadata['allowed_push_host'] = 'https://rubygems.org'
 
-  s.add_runtime_dependency('browser_sniffer', '~> 1.4.0')
+  s.add_runtime_dependency('browser_sniffer', '~> 2.0')
   s.add_runtime_dependency('omniauth-rails_csrf_protection')
   s.add_runtime_dependency('rails', '> 5.2.1')
   s.add_runtime_dependency('shopify_api', '~> 9.4')


### PR DESCRIPTION
Cherry-pick https://github.com/Shopify/shopify_app/pull/1474/commits back to an older version so that our app can pass the updated security checks within Shopify, without us needing to do the full upgrade to the latest version of the gem today.